### PR TITLE
Update Submodules url

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "jni/opensl_stream"]
 	path = jni/opensl_stream
-	url = git://github.com/nettoyeurny/opensl_stream.git
+	url = https://github.com/nettoyeurny/opensl_stream.git
 [submodule "pure-data"]
 	path = pure-data
-	url = git://github.com/pure-data/pure-data
+	url = https://github.com/pure-data/pure-data


### PR DESCRIPTION
Following GitHub’s security update as of 15/03/2022, “(…) any [url] starting with git://, should be changed to a supported format.”

Read more here: https://github.blog/2021-09-01-improving-git-protocol-security-github/